### PR TITLE
feature/change heredoc to tmpfile

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -70,4 +70,7 @@ void				setup_signals(void);
 /* safe_*.c */
 int					safe_dup(int fildes);
 int					safe_dup2(int fildes, int fildes2);
+
+// XXX: 仮置き
+void	delete_tmp_files(void);
 #endif

--- a/include/redirect.h
+++ b/include/redirect.h
@@ -6,7 +6,7 @@
 # include "token.h"
 
 // void				ft_heredoc_output(int fd);
-int					ft_heredoc(t_token *delimi_token, t_mgr *mgr);
+int					ft_heredoc(t_redir *redir, t_mgr *mgr);
 void				exec_redir(t_redir *redir_list, t_mgr *mgr);
 
 typedef struct s_fd_mgr

--- a/src/exec_redir.c
+++ b/src/exec_redir.c
@@ -113,7 +113,7 @@ void	exec_redir(t_redir *redir_list, t_mgr *mgr)
 	{
 		expand_redir_for_exit_status(redir, mgr->status);
 		if (redir->redir_type == TK_HEREDOC) // eofを引数に入れる
-			filefd = ft_heredoc(redir->word_list->token, mgr);
+			filefd = ft_heredoc(redir, mgr);
 		else
 			filefd = open_filepath(redir);
 		if (filefd == -1)

--- a/src/executor.c
+++ b/src/executor.c
@@ -139,10 +139,9 @@ void	run_cmd(t_cmd *cmd, t_mgr *mgr)
 	else if (cmd->type == EXEC)
 	{
 		ecmd = (t_execcmd *)cmd;
-		exec_redir(ecmd->redir_list, mgr); // TODO: 呼び出し位置をあとで考える
-		exec_cmd(cmd, mgr);                // ここか、この中でbuilt-inの呼び出し
-											// reset_fd(cmd); <- リソース管理
-											// backup_fd(cmd); <- fdの復旧？（本来は親プロセス用）
+		exec_redir(ecmd->redir_list, mgr);
+		exec_cmd(cmd, mgr);
+		// restore_fd(cmd); <- saved_stdin, saved_stdoutを使っているのでいらない
 	}
 	else if (cmd->type == PIPE)
 	{

--- a/src/ft_readline.c
+++ b/src/ft_readline.c
@@ -115,7 +115,8 @@ void	reset_resources(t_mgr *mgr)
 {
 	if (mgr->status == 0 && mgr->syntax_error) // これなんだっけ？
 		mgr->status = 1;
-	free_tokens(mgr->token); 
+	delete_tmp_files();
+	free_tokens(mgr->token);
 	free_cmd(mgr->cmd);
 	mgr->token = NULL;
 	mgr->cmd = NULL;

--- a/src/heredoc.c
+++ b/src/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/13 19:24:36 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2024/08/07 16:12:13 by sakitaha         ###   ########.fr       */
+/*   Updated: 2024/08/07 16:16:49 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,12 +52,13 @@ static void	expand_heredoc(char **line, t_hash_table *env_table)
 
 /**
  * 一時ファイル名を生成するための関数。index を用いてファイル名を作成
- *  */
+ * */
 static char	*generate_tmp_file_name(int index)
 {
-	char	*index_str = ft_itoa(index);
-	char		*tmp_file_name;
+	char	*index_str;
+	char	*tmp_file_name;
 
+	index_str = ft_itoa(index);
 	if (!index_str)
 	{
 		assert_error("ft_itoa failed", "generate_tmp_file_name");
@@ -78,7 +79,7 @@ static char	*generate_tmp_file_name(int index)
 
 /**
  * 存在しない一意な一時ファイル名を生成する関数
- */
+ * */
 static char	*create_unique_tmp_file_name(void)
 {
 	char	*tmp_file_name;
@@ -104,7 +105,7 @@ static char	*create_unique_tmp_file_name(void)
 
 /**
  * heredoc の入力を処理し、一時ファイルに書き込む関数
- */
+ * */
 int	ft_heredoc(t_redir *redir, t_mgr *mgr)
 {
 	char		*line;
@@ -146,11 +147,33 @@ int	ft_heredoc(t_redir *redir, t_mgr *mgr)
 		assert_error("open failed", "open_tmpfile for read");
 		return (-1);
 	}
-	free(redir->word_list->token->word);
-	redir->word_list->token->word = file_name; // あとでfileを削除するためにfile_nameを保存
 	return (fd);
 }
 
+/**
+ *  一時ファイルの削除関数 <- 1行処理ごとに一括でcleanupする
+ * */
+void	delete_tmp_files(void)
+{
+	int		index;
+	char	*file_name;
+
+	index = 0;
+	while (true)
+	{
+		file_name = generate_tmp_file_name(index);
+		if (!file_name)
+			break ;
+		if (access(file_name, F_OK) == -1) // まだ存在しないファイル名
+		{
+			free(file_name);
+			break ;
+		}
+		unlink(file_name); // 一時ファイルを削除
+		free(file_name);
+		index++;
+	}
+}
 
 // int	ft_heredoc(t_token *delimi_token, t_mgr *mgr)
 // {


### PR DESCRIPTION
- **heredocを一時ファイルで処理するように変更 /tmpディレクトリ使用**
- **一時ファイル（heredoc用）の削除**

close #51 

### 動作確認

以下のシンプルなケースで動作確認済み:

- `cat <<EOF`
- `cat <<EOF >tmpfile`

```sh
minishell$ cat <<EOF
heredoc> test 0
heredoc> EOF
test 0

minishell$ cat <<EOF > tmpfile
heredoc> test 1
heredoc> EOF
```

### 今後の作業予定

1. ロックファイルを使って複数のheredocが同時に走らないように制御する処理。
   例:
   ```c
   while (ロックファイルが存在する限り)
       sleep(1); // sleep関数が許可されていないが、どうする？
   fd = open(tmp_file_name, O_RDWR | O_CREAT | O_TRUNC, 0644);
   free(tmp_file_name);
   if (fd < 0)
   {
       assert_error("open failed", "open_tmpfile");
       return (-1);
   }
   return (fd);
   ```

2. 無効なFDが入力された時の扱い。
   例:
   - `0<<` 正常
   - `1<<` 無効なFD（error msgを出力して終了）, $? = 1
   - `2<<` その他のエラー（error msgなし / heredocの入力値は無視される）