### PR TITLE
feature/heredoc lock file

### DIFF
--- a/include/ft_readline.h
+++ b/include/ft_readline.h
@@ -2,13 +2,11 @@
 #ifndef READLINE_H
 # define READLINE_H
 
+# include "expander.h"
+# include "heredoc.h"
 # include "lexer.h"
 # include "parser.h"
 # include "token.h"
-# include "expander.h"
-# include <stdio.h>
-# include <readline/history.h>
-# include <readline/readline.h>
 
 void	ft_readline(t_mgr *mgr);
 void	interpret(char *line, t_mgr *mgr);

--- a/include/heredoc.h
+++ b/include/heredoc.h
@@ -1,0 +1,14 @@
+#ifndef HEREDOC_H
+# define HEREDOC_H
+
+# include "expander.h"
+# include "minishell.h"
+
+# define FILE_TEMPLATE "/tmp/heredoc"
+# define HEREDOC_MAX_FILES 10000
+
+void	run_heredoc(t_cmd *cmd, t_mgr *mgr);
+void	delete_tmp_files(void);
+// void				ft_heredoc_output(int fd); <- heredoc関連なのでここに移動
+
+#endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -4,7 +4,7 @@
 
 # include "ast.h"
 # include "env.h"
-#include <stdio.h>  // これを追加
+# include <stdio.h>  // ?
 # include "ft_hash.h"
 # include "token.h"
 # include <ctype.h>
@@ -21,6 +21,13 @@
 # include <string.h>
 # include <sys/wait.h>
 # include <unistd.h>
+# include <fcntl.h>
+# include <readline/readline.h>
+# include <stdlib.h>
+# include <unistd.h>
+# include <readline/history.h>
+# include <readline/readline.h>
+# include <stdio.h>
 
 typedef struct s_mgr
 {
@@ -71,6 +78,5 @@ void				setup_signals(void);
 int					safe_dup(int fildes);
 int					safe_dup2(int fildes, int fildes2);
 
-// XXX: 仮置き
-void	delete_tmp_files(void);
+
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -70,4 +70,7 @@ void				setup_signals(void);
 /* safe_*.c */
 int					safe_dup(int fildes);
 int					safe_dup2(int fildes, int fildes2);
+
+// XXX: 仮置き
+void	delete_tmp_files(void);
 #endif

--- a/include/redirect.h
+++ b/include/redirect.h
@@ -5,14 +5,14 @@
 # include "minishell.h"
 # include "token.h"
 
-// void				ft_heredoc_output(int fd);
-int					ft_heredoc(t_redir *redir, t_mgr *mgr);
 void				exec_redir(t_redir *redir_list, t_mgr *mgr);
 
+/*
+XXX: 使われていない。削除でいい？
 typedef struct s_fd_mgr
 {
 	int				fd;
 	struct s_fd_mgr	*next;
 }					t_fd_mgr;
-
+ */
 #endif

--- a/include/redirect.h
+++ b/include/redirect.h
@@ -6,7 +6,7 @@
 # include "token.h"
 
 // void				ft_heredoc_output(int fd);
-int					ft_heredoc(t_token *delimi_token, t_mgr *mgr);
+int					ft_heredoc(t_redir *redir, t_mgr *mgr);
 void				exec_redir(t_redir *redir_list, t_mgr *mgr);
 
 typedef struct s_fd_mgr

--- a/src/exec_redir.c
+++ b/src/exec_redir.c
@@ -26,19 +26,12 @@ static bool	is_valid_redir(t_redir *redir)
 
 static int	get_open_flag(t_token_type redir_type)
 {
-	if (redir_type == TK_REDIR_IN)
+	if (redir_type == TK_REDIR_IN || redir_type == TK_HEREDOC)
 		return (O_RDONLY | O_CLOEXEC);
 	else if (redir_type == TK_REDIR_OUT)
 		return (O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC);
 	else if (redir_type == TK_APPEND)
 		return (O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC);
-	else if (redir_type == TK_HEREDOC)
-	{
-		// このケースは到達しないはず
-		assert_error("Error: HEREDOC handling should not reach get_open_flag\n",
-			"get_open_flag failed");
-		return (-2);
-	}
 	assert_error("Unsupported redirection type", "get_open_flag failed");
 	return (-1);
 }
@@ -58,7 +51,7 @@ static int	open_filepath(t_redir *redir)
 		assert_error("Error: get_open_flag failed\n", "open_file\n");
 		return (-1);
 	}
-	if (redir->redir_type == TK_REDIR_IN)
+	if (redir->redir_type == TK_REDIR_IN || redir->redir_type == TK_HEREDOC)
 		fd = open(path, oflag);
 	else
 		fd = open(path, oflag, mode);
@@ -112,11 +105,7 @@ void	exec_redir(t_redir *redir_list, t_mgr *mgr)
 	while (redir)
 	{
 		expand_redir_for_exit_status(redir, mgr->status);
-		if (redir->redir_type == TK_HEREDOC) // eofを引数に入れる
-		;
-			// filefd = ft_heredoc(redir, mgr); ここのルートはあとで修正
-		else
-			filefd = open_filepath(redir);
+		filefd = open_filepath(redir);
 		if (filefd == -1)
 			return ; // error msgは先の関数内で出力, redir中止
 		if (is_valid_redir(redir))

--- a/src/exec_redir.c
+++ b/src/exec_redir.c
@@ -113,7 +113,7 @@ void	exec_redir(t_redir *redir_list, t_mgr *mgr)
 	{
 		expand_redir_for_exit_status(redir, mgr->status);
 		if (redir->redir_type == TK_HEREDOC) // eofを引数に入れる
-			filefd = ft_heredoc(redir->word_list->token, mgr);
+			filefd = ft_heredoc(redir, mgr);
 		else
 			filefd = open_filepath(redir);
 		if (filefd == -1)

--- a/src/exec_redir.c
+++ b/src/exec_redir.c
@@ -113,7 +113,8 @@ void	exec_redir(t_redir *redir_list, t_mgr *mgr)
 	{
 		expand_redir_for_exit_status(redir, mgr->status);
 		if (redir->redir_type == TK_HEREDOC) // eofを引数に入れる
-			filefd = ft_heredoc(redir, mgr);
+		;
+			// filefd = ft_heredoc(redir, mgr); ここのルートはあとで修正
 		else
 			filefd = open_filepath(redir);
 		if (filefd == -1)

--- a/src/executor.c
+++ b/src/executor.c
@@ -139,10 +139,9 @@ void	run_cmd(t_cmd *cmd, t_mgr *mgr)
 	else if (cmd->type == EXEC)
 	{
 		ecmd = (t_execcmd *)cmd;
-		exec_redir(ecmd->redir_list, mgr); // TODO: 呼び出し位置をあとで考える
-		exec_cmd(cmd, mgr);                // ここか、この中でbuilt-inの呼び出し
-											// reset_fd(cmd); <- リソース管理
-											// backup_fd(cmd); <- fdの復旧？（本来は親プロセス用）
+		exec_redir(ecmd->redir_list, mgr);
+		exec_cmd(cmd, mgr);
+		// restore_fd(cmd); <- saved_stdin, saved_stdoutを使っているのでいらない
 	}
 	else if (cmd->type == PIPE)
 	{

--- a/src/ft_readline.c
+++ b/src/ft_readline.c
@@ -115,7 +115,8 @@ void	reset_resources(t_mgr *mgr)
 {
 	if (mgr->status == 0 && mgr->syntax_error) // これなんだっけ？
 		mgr->status = 1;
-	free_tokens(mgr->token); 
+	delete_tmp_files();
+	free_tokens(mgr->token);
 	free_cmd(mgr->cmd);
 	mgr->token = NULL;
 	mgr->cmd = NULL;

--- a/src/ft_readline.c
+++ b/src/ft_readline.c
@@ -143,6 +143,7 @@ void	interpret(char *line, t_mgr *mgr)
 	}
 	// print_cmd(mgr->cmd); // デバッグ用の出力
 	run_expansion(mgr->cmd, mgr->env_table);
+	run_heredoc(mgr->cmd, mgr);
 	run_cmd(mgr->cmd, mgr);
 }
 

--- a/src/heredoc.c
+++ b/src/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/13 19:24:36 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2024/08/07 16:12:13 by sakitaha         ###   ########.fr       */
+/*   Updated: 2024/08/07 16:16:49 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,12 +52,13 @@ static void	expand_heredoc(char **line, t_hash_table *env_table)
 
 /**
  * 一時ファイル名を生成するための関数。index を用いてファイル名を作成
- *  */
+ * */
 static char	*generate_tmp_file_name(int index)
 {
-	char	*index_str = ft_itoa(index);
-	char		*tmp_file_name;
+	char	*index_str;
+	char	*tmp_file_name;
 
+	index_str = ft_itoa(index);
 	if (!index_str)
 	{
 		assert_error("ft_itoa failed", "generate_tmp_file_name");
@@ -78,7 +79,7 @@ static char	*generate_tmp_file_name(int index)
 
 /**
  * 存在しない一意な一時ファイル名を生成する関数
- */
+ * */
 static char	*create_unique_tmp_file_name(void)
 {
 	char	*tmp_file_name;
@@ -104,7 +105,7 @@ static char	*create_unique_tmp_file_name(void)
 
 /**
  * heredoc の入力を処理し、一時ファイルに書き込む関数
- */
+ * */
 int	ft_heredoc(t_redir *redir, t_mgr *mgr)
 {
 	char		*line;
@@ -146,11 +147,33 @@ int	ft_heredoc(t_redir *redir, t_mgr *mgr)
 		assert_error("open failed", "open_tmpfile for read");
 		return (-1);
 	}
-	free(redir->word_list->token->word);
-	redir->word_list->token->word = file_name; // あとでfileを削除するためにfile_nameを保存
 	return (fd);
 }
 
+/**
+ *  一時ファイルの削除関数 <- 1行処理ごとに一括でcleanupする
+ * */
+void	delete_tmp_files(void)
+{
+	int		index;
+	char	*file_name;
+
+	index = 0;
+	while (true)
+	{
+		file_name = generate_tmp_file_name(index);
+		if (!file_name)
+			break ;
+		if (access(file_name, F_OK) == -1) // まだ存在しないファイル名
+		{
+			free(file_name);
+			break ;
+		}
+		unlink(file_name); // 一時ファイルを削除
+		free(file_name);
+		index++;
+	}
+}
 
 // int	ft_heredoc(t_token *delimi_token, t_mgr *mgr)
 // {


### PR DESCRIPTION
### 内容

- **heredocを一時ファイルで処理するように変更** (/tmpディレクトリ使用)
- **一時ファイル（heredoc用）の削除**
- **heredocの実行場所を、expandとexecの間に変更**
- **ファイル化したheredocを、redir inと同様に扱うように変更**

ブランチ名に反してlock fileは使わず、expand->heredoc->execという順序でmainプロセス中でheredoc処理を行うように変更しました。

fix #48

### 動作確認済みの例

以下のコマンドで動作確認を行いました。

1. シンプルなheredocの入力と表示:
   ```sh
   cat <<EOF
   heredoc> simple heredoc
   heredoc> EOF
   ```

2. heredocの入力をファイルに書き込む:
   ```sh
   cat <<EOF > testfile
   heredoc> writing to a testfile
   heredoc> EOF
   ```

3. パイプと組み合わせたheredocの入力と表示:
   ```sh
   cat <<EOF | cat
   heredoc> pipe test
   heredoc> EOF
   ```

4. 複数のheredocを使用:
   ```sh
   cat <<EOF1 | cat <<EOF2
   heredoc> 1st heredoc
   heredoc> EOF1
   heredoc> 2nd heredoc
   heredoc> EOF2
   ```

5. heredocの入力をファイルに書き込み、同時に標準出力に表示:
   ```sh
   cat <<EOF > fileA | cat <<EOF2
   heredoc> 1st heredoc to fileA
   heredoc> EOF
   heredoc> 2nd heredoc to stdout
   heredoc> EOF2
   ```

6. リダイレクトとパイプの組み合わせ:
   ```sh
   cat <<EOF > testfile | cat
   heredoc> redirect and pipe test
   heredoc> EOF
   ```
