### PR TITLE
lexer関数のエラー修正

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   lexer.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: koseki.yusuke <koseki.yusuke@student.42    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/11 01:52:50 by sakitaha          #+#    #+#             */
-/*   Updated: 2024/09/11 02:20:26 by sakitaha         ###   ########.fr       */
+/*   Updated: 2024/09/22 16:41:19 by koseki.yusu      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,7 +62,7 @@ static t_token	*add_eof_token(t_token *cur_token, t_token *head_token)
 		free_tokens(head_token);
 		return (NULL);
 	}
-	return (head_token->next);
+	return (head_token);
 }
 
 static t_token	*create_tokens(char *s, t_token *head_token)


### PR DESCRIPTION
```
static t_token	*add_eof_token(t_token *cur_token, t_token *head_token)
{
	cur_token->next = new_token(TK_EOF, NULL, NULL);
	if (!cur_token->next)
	{
		free_tokens(head_token);
		return (NULL);
	}
	return (head_token);
}
```
add_eof_token関数の返り値をhead_token->nextからhead_tokenに修正しました. (lexer関数のreturn (add_eof_token(cur_token, head_token.next));の時点でhead_token.nextが渡っていたため.)