### PR TITLE
`exit` の終了ステータス処理の修正

### DIFF
--- a/include/ft_strtol.h
+++ b/include/ft_strtol.h
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/11 02:44:37 by sakitaha          #+#    #+#             */
-/*   Updated: 2024/09/11 02:44:40 by sakitaha         ###   ########.fr       */
+/*   Updated: 2024/10/02 16:18:42 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,7 @@
 # include <stdbool.h>
 # include <stddef.h>
 
+int		ft_isspace_custom(int c);
 void	skip_space(const char **str);
 bool	check_sign(const char **str);
 bool	is_valid_digit(char c, int base);

--- a/src/builtin_exit.c
+++ b/src/builtin_exit.c
@@ -3,14 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_exit.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: koseki.yusuke <koseki.yusuke@student.42    +#+  +:+       +#+        */
+/*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/17 13:48:16 by koseki.yusu       #+#    #+#             */
-/*   Updated: 2024/09/07 21:54:24 by koseki.yusu      ###   ########.fr       */
+/*   Updated: 2024/10/02 17:55:12 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtin_cmd.h"
+#include "error.h"
+#include "ft_strtol.h"
 #include <errno.h>
 
 static int	check_overflow(long long num, int onedigit, int type)
@@ -52,39 +54,50 @@ long	ft_atoi(const char *str)
 	return (type * num);
 }
 
-bool	is_numeric(char *s)
+static bool	is_valid_endptr(char *endptr)
 {
-	if (!ft_isdigit(*s))
+	if (!endptr)
 		return (false);
-	while (*s)
+	while (*endptr)
 	{
-		if (!ft_isdigit(*s))
+		if (!ft_isspace_custom(*endptr))
 			return (false);
-		s++;
+		endptr++;
 	}
 	return (true);
 }
 
+static long	parse_exit_arg(char **argv)
+{
+	long	status_long;
+	char	*endptr;
+
+	endptr = NULL;
+	errno = 0;
+	status_long = ft_strtol(argv[1], &endptr, 10);
+	if (errno != 0 || !is_valid_endptr(endptr))
+	{
+		report_error("exit", argv[1], "numeric argument required");
+		return (255);
+	}
+	if (argv[2])
+	{
+		report_error("exit", 0, "too many arguments");
+		return (1);
+	}
+	return (status_long);
+}
+
 int	builtin_exit(char **argv)
 {
-	char	*arg;
-	int		status;
+	long	status_long;
 
 	if (argv[1] == NULL)
 		exit(0);
-	if (argv[2])
+	status_long = parse_exit_arg(argv);
+	if (status_long == 1 && argv[2])
 	{
-		perror("exit: too many arguments");
 		return (1);
 	}
-	arg = argv[1];
-	if (is_numeric(arg))
-	{
-		errno = 0;
-		status = ft_atoi(arg);
-		if (errno == 0)
-			exit(status);
-	}
-	perror("exit: numeric argument required");
-	exit(255);
+	exit((int)status_long & 0xff);
 }

--- a/src/executor.c
+++ b/src/executor.c
@@ -6,11 +6,12 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/31 22:11:11 by sakitaha          #+#    #+#             */
-/*   Updated: 2024/09/24 21:48:42 by sakitaha         ###   ########.fr       */
+/*   Updated: 2024/10/02 14:25:07 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtin_cmd.h"
+#include "error.h"
 #include "executor.h"
 #include "free.h"
 #include "xlibc.h"
@@ -48,6 +49,20 @@ static void	restore_std_fds(int saved_stdin, int saved_stdout, int saved_stderr)
 	close(saved_stderr);
 }
 
+static t_status	validate_cmd_arg(char **argv)
+{
+	if (!argv[0] || *argv[0] == '\0')
+	{
+		return (SC_SUCCESS);
+	}
+	if (ft_strcmp(argv[0], ".") == 0)
+	{
+		report_error(argv[0], 0, "unsupported feature");
+		return (SC_BADUSAGE);
+	}
+	return (SC_SUCCESS);
+}
+
 static t_status	process_exec(t_execcmd *ecmd, t_mgr *mgr)
 {
 	int		status;
@@ -62,6 +77,8 @@ static t_status	process_exec(t_execcmd *ecmd, t_mgr *mgr)
 	}
 	argv = convert_list_to_array(ecmd->arg_list);
 	status = exec_redir(ecmd->redir_list, argv);
+	if (status == SC_SUCCESS && argv)
+		status = validate_cmd_arg(argv);
 	if (status == SC_SUCCESS && argv)
 		status = exec_cmd(argv, mgr);
 	free_argv(argv);

--- a/src/ft_strtol.c
+++ b/src/ft_strtol.c
@@ -6,7 +6,7 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/11 02:37:33 by sakitaha          #+#    #+#             */
-/*   Updated: 2024/09/11 02:37:36 by sakitaha         ###   ########.fr       */
+/*   Updated: 2024/10/02 16:19:59 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -111,55 +111,3 @@ long	ft_strtol(const char *str, char **endptr, int base)
 	base = confirm_base(&str, endptr, base);
 	return (convert(str, is_negative, endptr, base));
 }
-
-/*
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-
-void	test_strtol(const char *str, int base)
-{
-	char	*end;
-	char	*ft_end;
-	long	res;
-	long	ft_res;
-
-	printf("Testing: '%s' with base %d\n", str, base);
-	errno = 0;
-	res = strtol(str, &end, base);
-	printf("Og_strtol : %ld, errno: %d, end: '%s'\n", res, errno, end);
-	errno = 0;
-	ft_res = ft_strtol(str, &ft_end, base);
-	printf("ft_strtol : %ld, errno: %d, end: '%s'\n", ft_res, errno, ft_end);
-	printf("-------------------------------------------------\n\n");
-}
-
-int	main(void)
-{
-	test_strtol("42", 0);
-	test_strtol("0755", 0);
-	test_strtol("0x1A", 0);
-	test_strtol("101010", 2);
-	test_strtol("-101010", 2);
-	test_strtol("0436", 8);
-	test_strtol("0xff", 16);
-	test_strtol("123abc", 10);
-	test_strtol("999999999999999999999999999999", 10);
-	test_strtol("-999999999999999999999999999999", 10);
-	test_strtol("0", 0);
-	test_strtol("0x", 0);
-	test_strtol("0xzz", 0);
-	test_strtol("-z", 0);
-	test_strtol("0z", 0);
-	test_strtol("abc", 10);
-	test_strtol("Z", 36);
-	test_strtol("10", 36);
-	test_strtol("", 10);
-	test_strtol(" ", 10);
-	test_strtol("-apple00", 10);
-	test_strtol("123", 37);
-	test_strtol("123", 1);
-	return (0);
-}
-
- */

--- a/src/ft_strtol_utils.c
+++ b/src/ft_strtol_utils.c
@@ -6,20 +6,20 @@
 /*   By: sakitaha <sakitaha@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/11 01:06:43 by sakitaha          #+#    #+#             */
-/*   Updated: 2024/09/11 01:06:44 by sakitaha         ###   ########.fr       */
+/*   Updated: 2024/10/02 16:18:30 by sakitaha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "ft_strtol.h"
 
-static int	ft_isspace(int c)
+int	ft_isspace_custom(int c)
 {
-	return (('\t' <= c && c <= '\r') || c == ' ');
+	return (c == ' ' || c == '\t');
 }
 
 void	skip_space(const char **str)
 {
-	while (ft_isspace(**str))
+	while (ft_isspace_custom(**str))
 	{
 		(*str)++;
 	}


### PR DESCRIPTION
### タイトル
`exit` の終了ステータス処理の修正

### 概要
- **`exit` コマンドの終了ステータス処理を修正し、bash の挙動と一致させる**
  - 数値以外の引数（例: `invalid` や `9223372036854775808`）の場合、`numeric argument required` エラーを表示し、終了ステータスを `255` とする
  - 複数の引数（例: `exit 44 22`）の場合、`too many arguments` エラーを表示し、終了ステータス `1` を返す
  - `INT_MAX` や `INT_MIN` を超える値でも正しく処理されるように修正

### 動作確認項目
1. **有効なステータス**  
   - `exit 44` → `44`  
   - `exit ' 22 '` → `22`  
2. **無効な引数**  
   - `exit invalid` → `numeric argument required` → `255`  
   - `exit 9223372036854775808` → `numeric argument required` → `255`  
3. **複数引数**  
   - `exit 44 22` → `too many arguments` → `1`  
4. **境界値の確認**  
   - `exit 2147483647` → `255`  
   - `exit 2147483648` → `0`  
   - `exit -2147483648` → `0`  
   - `exit -2147483649` → `numeric argument required` → `255`  

### 関連 issue
- ref #100  
- close #108  